### PR TITLE
#20 Removed nonfree switch

### DIFF
--- a/patch/linux/build_ffmpeg_proprietary_codecs.patch
+++ b/patch/linux/build_ffmpeg_proprietary_codecs.patch
@@ -1,16 +1,8 @@
 diff --git a/chromium/scripts/build_ffmpeg.py b/chromium/scripts/build_ffmpeg.py
-index cfbe54e..9432f56 100755
+index 5b478be..deb253b 100755
 --- a/chromium/scripts/build_ffmpeg.py
 +++ b/chromium/scripts/build_ffmpeg.py
-@@ -297,6 +297,7 @@ def main(argv):
-       '--enable-fft',
-       '--enable-rdft',
-       '--enable-static',
-+      '--enable-nonfree',
-
-       # Disable features.
-       '--disable-bzlib',
-@@ -532,9 +533,9 @@ def main(argv):
+@@ -551,9 +551,9 @@ def main(argv):
 
    # Google Chrome & ChromeOS specific configuration.
    configure_flags['Chrome'].extend([

--- a/patch/mac/build_ffmpeg_proprietary_codecs.patch
+++ b/patch/mac/build_ffmpeg_proprietary_codecs.patch
@@ -1,16 +1,8 @@
 diff --git a/chromium/scripts/build_ffmpeg.py b/chromium/scripts/build_ffmpeg.py
-index cfbe54e..9432f56 100755
+index 5b478be..deb253b 100755
 --- a/chromium/scripts/build_ffmpeg.py
 +++ b/chromium/scripts/build_ffmpeg.py
-@@ -297,6 +297,7 @@ def main(argv):
-       '--enable-fft',
-       '--enable-rdft',
-       '--enable-static',
-+      '--enable-nonfree',
-
-       # Disable features.
-       '--disable-bzlib',
-@@ -532,9 +533,9 @@ def main(argv):
+@@ -551,9 +551,9 @@ def main(argv):
 
    # Google Chrome & ChromeOS specific configuration.
    configure_flags['Chrome'].extend([

--- a/patch/win/build_ffmpeg_proprietary_codecs.patch
+++ b/patch/win/build_ffmpeg_proprietary_codecs.patch
@@ -1,25 +1,17 @@
 diff --git a/chromium/scripts/build_ffmpeg.py b/chromium/scripts/build_ffmpeg.py
-index 5b478be..14c6f99 100755
+index 5b478be..deb253b 100755
 --- a/chromium/scripts/build_ffmpeg.py
 +++ b/chromium/scripts/build_ffmpeg.py
-@@ -300,6 +300,7 @@ def main(argv):
-       '--enable-fft',
-       '--enable-rdft',
-       '--enable-static',
-+      '--enable-nonfree',
-
-       # Disable features.
-       '--disable-bzlib',
-@@ -551,9 +552,9 @@ def main(argv):
+@@ -551,9 +551,9 @@ def main(argv):
 
    # Google Chrome & ChromeOS specific configuration.
    configure_flags['Chrome'].extend([
 -      '--enable-decoder=aac,h264,mp3',
 -      '--enable-demuxer=aac,mp3,mov',
 -      '--enable-parser=aac,h264,mpegaudio',
-+    '--enable-decoder=aac,ac3,eac3,h264,mp1,mp2,mp3,mpeg4,mpegvideo,hevc,flv,dca,flac',
-+    '--enable-demuxer=aac,h264,mp3,mp4,m4v,mpegvideo,mpegts,mov,avi,flv,dts,dtshd,vc1,flac',
-+    '--enable-parser=aac,ac3,aac3,h261,h263,h264,mepgvideo,mpeg4video,mpegaudio,dca,hevc,vc1,flac',
++      '--enable-decoder=aac,ac3,eac3,h264,mp1,mp2,mp3,mpeg4,mpegvideo,hevc,flv,dca,flac',
++      '--enable-demuxer=aac,h264,mp3,mp4,m4v,mpegvideo,mpegts,mov,avi,flv,dts,dtshd,vc1,flac',
++      '--enable-parser=aac,ac3,aac3,h261,h263,h264,mepgvideo,mpeg4video,mpegaudio,dca,hevc,vc1,flac',
    ])
 
-   # ChromiumOS specific configuration.
+   # ChromiumOS specific configuration


### PR DESCRIPTION
Thanks to Kagami.  Fraunhofer AAC library and FAAC are AAC encoders. We don't need them for decoding (ffmpeg has its own AAC decoder under LGPL), nonfree switch is for cuda, cuvid, libnpp ...etc